### PR TITLE
Fix sync remote error when downloading config files

### DIFF
--- a/pkg/store/client/core.go
+++ b/pkg/store/client/core.go
@@ -63,7 +63,7 @@ func (c *coreClient) SyncRemote() error {
 	d := time.Now().Add(10 * time.Second)
 	ctx, cancel := context.WithDeadline(context.Background(), d)
 	defer cancel()
-	creds, err := google.FindDefaultCredentials(ctx, storage.ScopeReadOnly)
+	creds, err := google.FindDefaultCredentials(ctx, storage.ScopeReadWrite)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/webapp/webapp.go
+++ b/pkg/webapp/webapp.go
@@ -271,7 +271,8 @@ func (h *Handler) Peers(w http.ResponseWriter, r *http.Request) {
 	configPath := filepath.Join(os.Getenv("$HOME/.wgapp/"), store.DBFileName)
 	client, err := storeclient.New(configPath, &bolt.Options{OpenFile: storeclient.FetchFromGCS})
 	if err != nil {
-		h.httpError(w, err.Error(), http.StatusInternalServerError)
+		msg := fmt.Sprintf("Error: failed creating client config: %v", err)
+		h.httpError(w, msg, http.StatusInternalServerError)
 		return
 	}
 	defer client.Close()
@@ -282,7 +283,8 @@ func (h *Handler) Peers(w http.ResponseWriter, r *http.Request) {
 		peerUID := r.FormValue("peer_uid")
 		peer, err := client.Peer().Get(peerUID)
 		if err != nil {
-			h.httpError(w, err.Error(), http.StatusInternalServerError)
+			msg := fmt.Sprintf("Error: failed fetching peer %v: %v", peerUID, err)
+			h.httpError(w, msg, http.StatusInternalServerError)
 			return
 		}
 		if peer == nil {
@@ -322,11 +324,13 @@ func (h *Handler) Peers(w http.ResponseWriter, r *http.Request) {
 			PublicKey:   nil,
 		}
 		if err := client.Peer().Update(peer); err != nil {
-			h.httpError(w, err.Error(), http.StatusInternalServerError)
+			msg := fmt.Sprintf("Error: failed updating peer %v: %v", peer.UID, err)
+			h.httpError(w, msg, http.StatusInternalServerError)
 			return
 		}
 		if err := client.SyncRemote(); err != nil {
-			h.httpError(w, err.Error(), http.StatusInternalServerError)
+			msg := fmt.Sprintf("Error: failed syncing peer %v: %v", peer.UID, err)
+			h.httpError(w, msg, http.StatusInternalServerError)
 			return
 		}
 		redirectURL := fmt.Sprintf("/peers/%s?vpn=%s", peer.Status.SecretValue, peer.GetServer())
@@ -334,7 +338,8 @@ func (h *Handler) Peers(w http.ResponseWriter, r *http.Request) {
 	case "GET":
 		peerList, err := client.Peer().List()
 		if err != nil {
-			h.httpError(w, err.Error(), http.StatusInternalServerError)
+			msg := fmt.Sprintf("Error: failed listing peers: %v", err)
+			h.httpError(w, msg, http.StatusInternalServerError)
 			return
 		}
 		var peer *api.Peer

--- a/terraform/platforms/gcp/variables.tf
+++ b/terraform/platforms/gcp/variables.tf
@@ -28,6 +28,7 @@ variable "gcp_activate_apis" {
   description = "A list of apis to activate, execute 'gcloud services list' to see the list of API's"
   default     = [
     "compute.googleapis.com",
+    "storage-api.googleapis.com"
   ]
 }
 


### PR DESCRIPTION
- Add context to errors
- Enable storage-api.googleapis.com by default